### PR TITLE
not all exe names are valid Ids

### DIFF
--- a/static/templates/AppxManifest.xml.in
+++ b/static/templates/AppxManifest.xml.in
@@ -27,7 +27,7 @@
     <Capability Name="internetClient" />
   </Capabilities>
   <Applications>
-    <Application Id="{{AppExecutable}}"  Executable="app\{{AppExecutable}}" EntryPoint="Windows.FullTrustApplication">
+    <Application Id="App"  Executable="app\{{AppExecutable}}" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements
           DisplayName="{{AppDisplayName}}"
           Description="{{PackageDescription}}"

--- a/test/unit/manifestation.spec.ts
+++ b/test/unit/manifestation.spec.ts
@@ -112,7 +112,7 @@ describe('manifestation', () => {
       expect(appManifestIn).toMatch(/<PublisherDisplayName>Jan Hannemann<\/PublisherDisplayName>/);
       expect(appManifestIn).toMatch(/<Logo>assets\\icon.png<\/Logo>/);
       expect(appManifestIn).toMatch(/<TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.14393.0" MaxVersionTested="10.0.14393.0" \/>/);
-      expect(appManifestIn).toMatch(/<Application Id="HelloMSIX.exe"  Executable="app\\HelloMSIX.exe" EntryPoint="Windows.FullTrustApplication">/);
+      expect(appManifestIn).toMatch(/<Application Id="App"  Executable="app\\HelloMSIX.exe" EntryPoint="Windows.FullTrustApplication">/);
       expect(appManifestIn).toMatch(/DisplayName="HelloMSIX"/);
       expect(appManifestIn).toMatch(/Description="HelloMSIX"/);
       expect(appManifestIn).toMatch(/Square44x44Logo="assets\\Square44x44Logo.png"/);


### PR DESCRIPTION
The App Id is only used intenrally when having more than one App entry. THis is not the case in our simple manifest generator.